### PR TITLE
fix: build process for enclave release

### DIFF
--- a/.github/sgxs-release.dockerfile
+++ b/.github/sgxs-release.dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
 RUN cargo install --locked --git https://github.com/mithril-security/rust-sgx.git --tag fortanix-sgx-tools_v0.5.1-mithril fortanix-sgx-tools sgxs-tools
 
 COPY Cargo.toml Cargo.lock rust-toolchain.toml  manifest.prod.template.toml ./
+COPY .cargo .cargo
 COPY src src
 COPY tar-rs-sgx tar-rs-sgx
 COPY tract tract


### PR DESCRIPTION
Bug description : 
Trying to connect to the enclave from the official release (https://github.com/mithril-security/blindai-preview/releases) (v0.0.2 and v0.0.1) results in enclave panic and the client cannot establish a HTTPS connection with the server.
```bash
$  ./runner/target/release/runner blindai_server.sgxs
Now listening on port 9923 and 9924
Attaching debugger
Error on exec SGX enclave 
 Enclave panicked..
```  
Insight : 
After a quick investigation, I found that the client was able to retrieve the required attestation elements from the untrusted port. The failure only happens when the client tries to connect on the attested TLS port of the enclave.

Cause : 
The Docker environment lacks the `.cargo/config` and therefore the enclave are built with the wrong compile flags.

Why did this fail at this specific step ?

I am not 100% sure, but I believe the following happens :
* The client initiate the TLS connection to the server
* The server and the client negociate the use of AES as the cipher
* The server tries to encrypt a message with AES but because the wrong compile flags have been used while building the enclave, ring has no available implementation of AES. (the config file would normally enable the target-feature aes, which makes aes-ni available).

Fix: Build with the right flags by adding the .cargo/config This solves the issue and anyway the enclave must be built with the right config.