### PR TITLE
Add mock server and client testing mode

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,5 +69,13 @@ jobs:
         tar czf blindai_server-$VERSION_TAG.tgz blindai_server.sgxs blindai_server.sig runner
         popd
 
-        GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} gh release create --verify-tag v$VERSION_TAG outdir/manifest.toml outdir/blindai_server-$VERSION_TAG.tgz
+        ./earthly --artifact +build-mock-server/* outdir/
+        pushd outdir
+        mv blindai_mock_server-x86_64-unknown-linux-gnu.tgz "blindai_mock_server-$VERSION_TAG-x86_64-unknown-linux-gnu.tgz"
+        popd
+
+        GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} gh release create --verify-tag v$VERSION_TAG \
+          outdir/manifest.toml \
+          "outdir/blindai_server-$VERSION_TAG.tgz" \
+          "outdir/blindai_mock_server-$VERSION_TAG-x86_64-unknown-linux-gnu.tgz"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "bytes",
+ "cfg-if",
  "digest",
  "env_logger",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ sgx-isa = { version = "0.4.0", features = ["serde"] }
 ureq = {version = "2.5.0", features = ["json"]}
 serde_bytes = "0.11.8"
 tiny_http = { path = "tiny-http" }
+cfg-if = "1.0.0"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/Earthfile
+++ b/Earthfile
@@ -8,8 +8,8 @@ ci:
     BUILD +build-release-enclave
     BUILD +build-release-runner
     BUILD +build-release-client
+    BUILD +build-mock-server
     BUILD +test-release
-
 
 
 publish:
@@ -47,6 +47,10 @@ prepare-test:
     RUN cd tests && bash generate_all_onnx_and_npz.sh
 
 dev-tests:
+    BUILD +dev-tests-sgx
+    BUILD +dev-tests-mock 
+
+dev-tests-base:
     FROM +prepare-test
 
     CACHE /usr/local/cargo/git
@@ -66,6 +70,9 @@ dev-tests:
     RUN cargo build --target x86_64-fortanix-unknown-sgx \
         && cargo build --target x86_64-fortanix-unknown-sgx --release
 
+    # compile the mock server
+    RUN cargo build --release
+    
     # compile Rust sources for the runner
     COPY runner runner
     CACHE /blindai-preview/runner/target
@@ -102,9 +109,17 @@ dev-tests:
 
     COPY manifest.dev.template.toml manifest.prod.template.toml ./
 
-    # end-to-end tests
+dev-tests-mock:
+    FROM +dev-tests-base
+    RUN cargo run --release & \
+        sleep 2 \
+        && cd tests \
+        && BLINDAI_SIMULATION_MODE=true bash run_all_end_to_end_tests.sh
 
-     RUN --privileged \
+dev-tests-sgx:
+    FROM +dev-tests-base
+    # end-to-end tests
+    RUN --privileged \
          --mount=type=bind-experimental,target=/var/run/aesmd/aesm.socket,source=/var/run/aesmd/aesm.socket  \
          --mount=type=bind-experimental,target=/dev/sgx/,source=/dev/sgx/  \
         ( cd /opt/intel/sgx-dcap-pccs && npm start pm2 ) & \
@@ -190,6 +205,45 @@ build-release-enclave:
     SAVE ARTIFACT $BIN_PATH.sgxs
     SAVE ARTIFACT $BIN_PATH.sig
     SAVE ARTIFACT manifest.toml
+
+build-mock-server:
+    # Manylinux2014 will be used to ensure the compatibility with Google Colab platforms and most of the linux distributions
+    FROM quay.io/pypa/manylinux2014_x86_64
+    WORKDIR blindai-preview
+
+    # Install dependencies and pre-install the rust toolchain declared via rust-toolchain.toml 
+    # for better caching
+    RUN curl -4 'https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init' --output /root/rustup-init && \
+        chmod +x /root/rustup-init && \
+        echo '1' | /root/rustup-init --default-toolchain nightly-2023-01-11-x86_64-unknown-linux-gnu && \
+        echo 'source /root/.cargo/env' >> /root/.bashrc && \
+        rm /root/rustup-init
+    ENV PATH="/root/.cargo/bin:$PATH"
+
+    CACHE /root/.cargo/git
+    CACHE /root/.cargo/registry
+    CACHE target
+
+    COPY rust-toolchain.toml Cargo.toml Cargo.lock ./
+    COPY .cargo .cargo
+    COPY src src
+    COPY tar-rs-sgx tar-rs-sgx
+    COPY tract tract
+    COPY ring-fortanix ring-fortanix
+    COPY tiny-http tiny-http
+    COPY rouille rouille
+
+    RUN sed -i 's/x86_64-fortanix-unknown-sgx/x86_64-unknown-linux-gnu/g' rust-toolchain.toml
+
+    RUN cargo build --locked --release
+
+    RUN mkdir bin \
+        && cp target/release/blindai_server bin/blindai_mock_server \
+        && pushd bin \
+        && tar czf blindai_mock_server-x86_64-unknown-linux-gnu.tgz blindai_mock_server \
+        && popd
+
+    SAVE ARTIFACT bin/blindai_mock_server-x86_64-unknown-linux-gnu.tgz
 
 build-release-runner:
     # Build the release version of the runner

--- a/client/blindai_preview/__init__.py
+++ b/client/blindai_preview/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "QuoteValidationError",
     "EnclaveHeldDataError",
     "IdentityError",
+    "testing",
 ]
 
 from .client import (
@@ -26,3 +27,4 @@ from ._dcap_attestation import (
     EnclaveHeldDataError,
     IdentityError,
 )
+from . import testing

--- a/client/blindai_preview/_dcap_attestation.py
+++ b/client/blindai_preview/_dcap_attestation.py
@@ -249,7 +249,7 @@ class EnclaveManifest:
     misc_mask: int  # 32-bits bitvector
 
     def __post_init__(self):
-        for (name, field_type) in self.__annotations__.items():
+        for name, field_type in self.__annotations__.items():
             if not isinstance(self.__dict__[name], field_type):
                 current_type = type(self.__dict__[name])
                 raise TypeError(

--- a/client/blindai_preview/testing.py
+++ b/client/blindai_preview/testing.py
@@ -1,0 +1,105 @@
+import subprocess
+import tarfile
+import urllib.request
+import io
+import os
+from urllib.error import HTTPError
+from os import path
+from subprocess import Popen
+
+from importlib_metadata import version
+from pathlib import Path
+
+app_version = version("blindai-preview")
+
+
+class MockServer:
+    """Mock server process handle"""
+
+    def __init__(self, process, _private=False):
+        if not _private:
+            raise NotImplementedError()
+        self._process = process
+
+    def stop(self) -> bool:
+        """Stop BlindAI mock server.
+
+        This method will kill the running server, if the provided MockServer is still running.
+        Args:
+            self (MockServer): Mock server process handle
+        Return:
+            bool, True if the server was successfully stopped.
+        Raises:
+            None
+        """
+
+        if self._process is not None and self._process.poll() is None:
+            print("Stopping BlindAI mock server...")
+            self._process.kill()
+            return True
+        else:
+            print("BlindAI mock server already stopped")
+            return False
+
+
+class NotFoundError(Exception):
+    """This exception is raised when there was an error opening an URL.
+    Args:
+        Args:
+        message (str): Error message.
+    """
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+
+def _extract_tar(data):
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+        tar.extractall(Path.cwd() / "bin")
+
+
+def _handle_download(path: Path, url: str, name: str, error_msg: str):
+    if not path.exists():
+        print(f"Downloading {name}...")
+        try:
+            response = urllib.request.urlopen(url)
+            _extract_tar(response.read())
+        except HTTPError as e:
+            raise NotFoundError(
+                "{}. Exact error code: {}".format(error_msg, e.code)
+            ) from None
+    else:
+        print("{} already installed".format(name))
+
+
+def _start_server(blindai_path: Path) -> MockServer:
+    blindai_path.chmod(0o755)
+    process = subprocess.Popen([blindai_path], env=os.environ)
+    return MockServer(process, _private=True)
+
+
+def start_mock_server() -> MockServer:
+    """Start BlindAI mock server for testing.
+    The method will download BlindAI Preview's mock server binary if needed.
+    The mock server is then started allowing to run the rest of your Google Colab/Jupyter Notebook environment.
+    Args:
+        None
+    Return:
+        MockServer object, the process of the running server.
+    Raises:
+        NotFoundError: Will be raised if one of the URL the wheel will try to access is invalid. This might mean that either there is no available binary of BlindAI's server.
+        Other exceptions might be raised by zipfile or urllib.request.
+    """
+    blindai_path = Path.cwd() / "bin" / "blindai_mock_server"
+
+    blindai_url = f"https://github.com/mithril-security/blindai-preview/releases/download/v{app_version}/blindai_mock_server-{app_version}-x86_64-unknown-linux-gnu.tgz"
+
+    _handle_download(
+        blindai_path,
+        blindai_url,
+        f"BlindAI mock server (version {app_version})",
+        "The release might not be available yet for the current version",
+    )
+    process = _start_server(blindai_path)
+    return process

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -2,7 +2,7 @@
 name = "blindai-preview"
 version = "0.0.5"
 description = ""
-authors = ["Corentin Lauverjat <corentin.lauverjat@mithrilsecurity.io>"]
+authors = ["Mithril Security <contact@mithrilsecurity.io>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,12 @@ fn get_collateral(quote: &[u8]) -> Result<SgxCollateral> {
 fn main() -> Result<()> {
     println!("BlindAI server is running at : 0.0.0.0:9923 and 0.0.0.0:9924");
 
+    const SERVER_NAME: &str = if cfg!(target_env = "sgx") {
+        "blindai_preview"
+    } else {
+        "blindai_preview mock (testing)"
+    };
+
     // Make debugging easier by enabling rust backtrace inside enclave
     std::env::set_var("RUST_BACKTRACE", "full");
     #[cfg(debug_assertions)]
@@ -110,6 +116,7 @@ fn main() -> Result<()> {
             )
             .with_status_code(500),
         }
+        .with_additional_header("Server", SERVER_NAME)
     }
 
     // Remote attestation

--- a/tests/assert_correctness.py
+++ b/tests/assert_correctness.py
@@ -1,3 +1,4 @@
+import os
 from blindai_preview import *
 import onnxruntime as rt
 import numpy as np
@@ -12,10 +13,14 @@ _, model_path, inputs_path = sys.argv
 inputs = dict(np.load(inputs_path))
 
 #blindai code
-client_v2 = connect(addr="localhost", hazmat_http_on_untrusted_port=True)
-response = client_v2.upload_model(model=model_path)
-run_response = client_v2.run_model(model_id=response.model_id, input_tensors=inputs)
-client_v2.delete_model(model_id = response.model_id)
+if os.environ.get('BLINDAI_SIMULATION_MODE') == "true":
+	client = connect(addr="localhost", hazmat_http_on_untrusted_port=True, simulation_mode=True)
+else:
+	client = connect(addr="localhost", hazmat_http_on_untrusted_port=True)
+
+response = client.upload_model(model=model_path)
+run_response = client.run_model(model_id=response.model_id, input_tensors=inputs)
+client.delete_model(model_id = response.model_id)
 
 #ort code
 sess = rt.InferenceSession(model_path)


### PR DESCRIPTION
This PR adds a server mock to BlindAI to make it easier to test. The server mock can be started from the python `blindai_preview`package. A simulation mode support was added as well to the client.

This makes it easy to test BlindAI locally or in a Google Colab/Jupyter Notebook environment.
This PR includes the necessary CI steps to build automatically the python package and the server when a new tag is available.

This is a rework of #12 from @JoFrost 

```
import blindai_preview.testing

# start mock server
server = blindai_preview.testing.start_mock_server()

# do your things ...

# stop mock server
server.stop()
``` 