### PR TITLE
Switch from trusted/untrusted to attested/unattested port

### DIFF
--- a/client/blindai_preview/_dcap_attestation.py
+++ b/client/blindai_preview/_dcap_attestation.py
@@ -125,7 +125,7 @@ def validate_attestation(
         enclave_held_data (bytes): Enclave held data
     Raises:
         QuoteValidationError: The quote could not be validated.
-        EnclaveHeldDataError: The enclave held data expected does not match the one in the quote. The expected enclave held data in BlindAI is the untrusted certificate to avoid man-in-the-middle attacks.
+        EnclaveHeldDataError: The enclave held data expected does not match the one in the quote. The expected enclave held data in BlindAI is a certificate to avoid man-in-the-middle attacks.
         NotAnEnclaveError: The enclave claims are not validated by the hardware provider, meaning that the claims cannot be verified using the hardware root of trust.
     Returns:
         -

--- a/client/examples/simple.py
+++ b/client/examples/simple.py
@@ -7,7 +7,7 @@ import numpy as np
 # This option is hazardous therefore it starts with hazmat_
 # Those options should generally not be used in production unless you
 # have carefully assessed the consequences.
-client_v2 = connect(addr="localhost", hazmat_http_on_untrusted_port=True)
+client_v2 = connect(addr="localhost", hazmat_http_on_unattested_port=True)
 
 response = client_v2.upload_model(model="../../tests/simple/simple.onnx")
 

--- a/client/tests/integration_test.py
+++ b/client/tests/integration_test.py
@@ -8,7 +8,7 @@ import blindai_preview
 
 def test_connect():
     client = blindai_preview.connect(
-        addr="localhost", hazmat_http_on_untrusted_port=True
+        addr="localhost", hazmat_http_on_unattested_port=True
     )
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,12 +63,12 @@ from blindai_preview.client import *
 import numpy as np
 
 # For test purpose, we want to avoid setting a TLS reverse proxy on top of
-# the untrusted port. We pass the hazmat_http_on_untrusted_port = True argument
-# to allow connecting to the untrusted port using plain HTTP instead of HTTPS.
+# the unattested port. We pass the hazmat_http_on_unattested_port = True argument
+# to allow connecting to the unattested port using plain HTTP instead of HTTPS.
 # This option is hazardous therefore it starts with hazmat_
 # Those options should generally not be used in production unless you
 # have carefully assessed the consequences.
-client_v2 = connect(addr="localhost", hazmat_http_on_untrusted_port=True)
+client_v2 = connect(addr="localhost", hazmat_http_on_unattested_port=True)
 
 response = client_v2.upload_model(model="../../tests/simple/simple.onnx")
 

--- a/tests/assert_correctness.py
+++ b/tests/assert_correctness.py
@@ -14,9 +14,9 @@ inputs = dict(np.load(inputs_path))
 
 #blindai code
 if os.environ.get('BLINDAI_SIMULATION_MODE') == "true":
-	client = connect(addr="localhost", hazmat_http_on_untrusted_port=True, simulation_mode=True)
+	client = connect(addr="localhost", hazmat_http_on_unattested_port=True, simulation_mode=True)
 else:
-	client = connect(addr="localhost", hazmat_http_on_untrusted_port=True)
+	client = connect(addr="localhost", hazmat_http_on_unattested_port=True)
 
 response = client.upload_model(model=model_path)
 run_response = client.run_model(model_id=response.model_id, input_tensors=inputs)


### PR DESCRIPTION
There has been some confusion on what trusted and untrusted port meant. Trusted and untrusted were chosen because they represent the trust that a client can give to a connection. But it was not clear enough (especially when looking at the code of the server). That's why we are changing the name : 
 *  trusted port/server -> attested port/server
 *  untrusted port/server -> unattested port/server 
This reflect better than one port is not using attestation and that the other is authenticated via SGX attestation.