### PR TITLE
Little doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Confidentiality is assured by hardware-enforced [**Trusted Execution Environment
 <!-- GETTING STARTED -->
 ## 🚀 Getting Started
 
-You can try out our [Quick tour](./docs/docs/getting-started/quick-tour.ipynb) in the documentation to discover BlindAI with a hands-on example using [COVID-Net](https://github.com/lindawangg/COVID-Net).
+We strongly recommend for you to get started with our [Quick tour](./docs/docs/getting-started/quick-tour.ipynb) to discover BlindAI with a hands-on example using [COVID-Net](https://github.com/lindawangg/COVID-Net).
 
 But here’s a taste of what using BlindAI could look like 🍒
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -5,6 +5,23 @@ Here's your guide to install BlindAI.
 
 There are different possible deployment methods. You can view the pros and cons of each one by opening the following boxes.
 
+??? example "Testing BlindAI without hardware security guarantees (*for testing only*)"
+
+	**✅ Pros**
+
+	- Quick and easy.
+	- Works on any device. Very few pre-requisites.
+	- Demos available on BlindAI GitHub.
+
+	**❌ Cons:**
+
+	- This option does not offer the hardware security guarantees of Intel SGX. **It is not suitable for production.**
+
+	🚀 If this is the right option for you, you can:
+
+	- **Check out our [Quick tour notebook](#Quick tour)**. This will show you how you can install and use BlindAI's client and server testing packages.
+	- **Test your own Python scripts or notebooks** using the `blindai_preview` PyPi packages with the `blindai_preview.testing` server.
+
 ??? success "Deploying BlindAI on Azure DCsv3 VM (*recommended*)"
 
 	**✅ Pros**
@@ -34,23 +51,6 @@ There are different possible deployment methods. You can view the pros and cons 
 
 	**🚀 <a href="#on-premise-deployment">Check out the On-premise section</a>**
 
-??? example "Testing BlindAI without hardware security guarantees (*for testing only*)"
-
-	**✅ Pros**
-
-	- Quick and easy.
-	- Works on any device. Very few pre-requisites.
-	- Demos available on BlindAI GitHub.
-
-	**❌ Cons:**
-
-	- This option does not offer the hardware security guarantees of Intel SGX. **It is not suitable for production.**
-
-	🚀 If this is the right option for you, you can:
-
-	- **Check out our [Quick tour notebook](#Quick tour)**. This will show you how you can install and use BlindAI's client and server testing packages.
-	- **Test your own Python scripts or notebooks** using the `blindai_preview` PyPi packages with the `blindai_preview.testing` server.
-	
 
 ## Deployment on Azure DCsv3
 ________________________________________________

--- a/docs/docs/getting-started/quick-tour.ipynb
+++ b/docs/docs/getting-started/quick-tour.ipynb
@@ -14,24 +14,23 @@
         "</div>\n",
         "______________________________\n",
         "\n",
-        "In this notebook, we will explore how BlindAI can be used to deploy AI models in a privacy-respecting manner. BlindAI is an AI deployment solution which offers strong privacy guarantees by processing user data in a SGX secure enclave.\n",
+        "In this notebook, we will explore how **BlindAI** can be used to **deploy AI models** while offering **strong privacy guarantees**. It does so by processing user data in a **SGX secure enclave**.\n",
         "\n",
-        "To let you discover BlindAI without having to install anything locally, we made [a Google Colab](https://colab.research.google.com/github/mithril-security/blindai-preview/blob/main/docs/docs/getting-started/quick-tour.ipynb) where you can directly follow this introduction tutorial. However, everything has been packaged and explained for you to be able to run this on your machine, if you wish to.  \n",
+        "To let you discover BlindAI without having to install anything locally, we made [**a Google Colab**](https://colab.research.google.com/github/mithril-security/blindai-preview/blob/main/docs/docs/getting-started/quick-tour.ipynb) where you can directly follow this introduction tutorial with or without a Google account. However, everything has been explained and packaged for you to be able to run tests on your machine, if you wish to.  \n",
         "\n",
         "> If you're still wondering why you should use BlindAI, you can go check [our introduction](https://blindai-preview.mithrilsecurity.io/en/latest/docs/getting-started/why-blindai/) on that topic. We'll focus on a hands-on demo in this tutorial.\n",
         "\n",
         "#### The scenario: predicting Covid-19 with chest X-rays\n",
         "\n",
-        "We will begin by taking the perspective of an AI company that has developed a model and wants to deploy it. Then, we will step into the shoes of a data owner with a sensitive dataset they want to run the model on. This will allow us to take you through the workflow of BlindAI and its main features.\n",
+        "We will begin by taking the perspective of an **AI company that has developed a model** and wants to deploy it. Then, we will step into the shoes of a **data owner with a sensitive dataset** they want to run the model on. This will allow us to take you through the **workflow** of BlindAI and its **main features**.\n",
         "\n",
-        "To make things more interesting, we will use a realistic but fictional example: predicting Covid-19 in patient chest X-ray images with Covid-NET. \n",
+        "To make things more interesting, we will use a realistic but fictional example: predicting Covid-19 in patient chest X-ray images **with Covid-NET**. \n",
         "\n",
-        "PixelHealth, an AI startup, has developed a neural network that can identify if a patient is affected by Covid-19 from their chest X-ray. \n",
-        "The respiratory medicine department of the Sacred Heart Hospital is interested in using the PixelHealth service to improve patient care. \n",
+        "PixelHealth, an AI startup, has developed a neural network that can identify if a patient is affected by Covid-19 from their chest X-ray. The respiratory medicine department of the Sacred Heart Hospital is interested in using the PixelHealth service to improve patient care. \n",
         "\n",
-        "The hospital can't afford the cost in time and money of an on-premise deployement on the hospital infrastructure, and the startup doesn't have the ressources to go through an independant security audit. Usually, this is where the collaboration ends because patient data is too sensitive to take any risk. But here, they decide to use BlindAI, which allows PixelHealth to deploy its model with the technical guarantees that patient data stays confidential. Using BlindAI, the hospital can benefit from AI assistance in diagnosis, and the AI company can retain its customer.\n",
+        "The hospital can't afford the cost of an on-premise deployement on the hospital infrastructure, and the startup doesn't have the ressources to go through an independant security audit. Usually, this is where the collaboration ends because patient data is too sensitive to take any risk. But here, both sides agree to use BlindAI, which allows PixelHealth to deploy its model with the technical guarantees that patient data stays confidential. Sacred Heart Hospital can benefit from AI assistance in diagnosis and the PixelHealth can retain its customer.\n",
         "\n",
-        "Let's get started. We will first need to download all the required dependencies for this notebook."
+        "Now, let's get started!"
       ]
     },
     {
@@ -46,7 +45,7 @@
         "\n",
         "### Installing required dependencies\n",
         "\n",
-        "Unless you're are running this notebook [on Google Colab](https://colab.research.google.com/github/mithril-security/blindai-preview/blob/main/docs/docs/getting-started/quick-tour.ipynb), you'll need to have installed [`Python`](https://www.python.org/downloads/) (3.8 or greater), [`wget`](https://pypi.org/project/wget/) and [`pip`](https://pypi.org/project/pip/) \n",
+        "Unless you're are running this notebook [on Google Colab](https://colab.research.google.com/github/mithril-security/blindai-preview/blob/main/docs/docs/getting-started/quick-tour.ipynb), you'll need to have installed [`Python`](https://www.python.org/downloads/) (3.8 or greater), [`wget`](https://pypi.org/project/wget/) and [`pip`](https://pypi.org/project/pip/). \n",
         "\n",
         "Then, you'll need to install the BlindAI-preview package."
       ]

--- a/docs/docs/getting-started/quick-tour.ipynb
+++ b/docs/docs/getting-started/quick-tour.ipynb
@@ -16,18 +16,20 @@
         "\n",
         "In this notebook, we will explore how BlindAI can be used to deploy AI models in a privacy-respecting manner. BlindAI is an AI deployment solution which offers strong privacy guarantees by processing user data in a SGX secure enclave.\n",
         "\n",
+        "To let you discover BlindAI without having to install anything locally, we made [a Google Colab](https://colab.research.google.com/github/mithril-security/blindai-preview/blob/main/docs/docs/getting-started/quick-tour.ipynb) where you can directly follow this introduction tutorial. However, everything has been packaged and explained for you to be able to run this on your machine, if you wish to.  \n",
+        "\n",
         "> If you're still wondering why you should use BlindAI, you can go check [our introduction](https://blindai-preview.mithrilsecurity.io/en/latest/docs/getting-started/why-blindai/) on that topic. We'll focus on a hands-on demo in this tutorial.\n",
+        "\n",
+        "#### The scenario: predicting Covid-19 with chest X-rays\n",
         "\n",
         "We will begin by taking the perspective of an AI company that has developed a model and wants to deploy it. Then, we will step into the shoes of a data owner with a sensitive dataset they want to run the model on. This will allow us to take you through the workflow of BlindAI and its main features.\n",
         "\n",
         "To make things more interesting, we will use a realistic but fictional example: predicting Covid-19 in patient chest X-ray images with Covid-NET. \n",
         "\n",
         "PixelHealth, an AI startup, has developed a neural network that can identify if a patient is affected by Covid-19 from their chest X-ray. \n",
-        "The respiratory medicine department of the Sacred Heart Hospital is interested in using the PixelHealth service to improve patient care. However, before using the solution on real patient data, the hospital must make sure that patient confidentiality is respected.\n",
+        "The respiratory medicine department of the Sacred Heart Hospital is interested in using the PixelHealth service to improve patient care. \n",
         "\n",
-        "Unfortunately this is easier said than done. The startup and the hospital cannot afford the cost in time and money of an on-premise deployment on the hospital infrastructure. Also the startup does not have the resources to go through an independent security audit. In the past, this would have been the end, and the solution would not have been implemented. It would have been a loose-loose situation where the hospital could not benefit from AI assistance in diagnosis, and the AI company would lose a customer. \n",
-        "\n",
-        "Fortunately, BlindAI provides a solution. It allows PixelHealth to deploy its model with the technical guarantees that patient data stays confidential. Using BlindAI, the hospital can benefit from AI assistance in diagnosis, and the AI company can retain its customer.\n",
+        "The hospital can't afford the cost in time and money of an on-premise deployement on the hospital infrastructure, and the startup doesn't have the ressources to go through an independant security audit. Usually, this is where the collaboration ends because patient data is too sensitive to take any risk. But here, they decide to use BlindAI, which allows PixelHealth to deploy its model with the technical guarantees that patient data stays confidential. Using BlindAI, the hospital can benefit from AI assistance in diagnosis, and the AI company can retain its customer.\n",
         "\n",
         "Let's get started. We will first need to download all the required dependencies for this notebook."
       ]
@@ -44,7 +46,7 @@
         "\n",
         "### Installing required dependencies\n",
         "\n",
-        "Unless you're are running this notebook on Google Colab, you'll need to have installed [`Python`](https://www.python.org/downloads/) (3.8 or greater), [`wget`](https://pypi.org/project/wget/) and [`pip`](https://pypi.org/project/pip/) \n",
+        "Unless you're are running this notebook [on Google Colab](https://colab.research.google.com/github/mithril-security/blindai-preview/blob/main/docs/docs/getting-started/quick-tour.ipynb), you'll need to have installed [`Python`](https://www.python.org/downloads/) (3.8 or greater), [`wget`](https://pypi.org/project/wget/) and [`pip`](https://pypi.org/project/pip/) \n",
         "\n",
         "Then, you'll need to install the BlindAI-preview package."
       ]

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ ________________________________________________________
 BlindAI facilitates  **privacy-friendly AI model deployment** by letting AI engineers upload and delete models to their secure server instance using our **Python API**. Clients can then connect to the server, upload their data and run models on it without compromising on privacy. 
 
 Data sent by users to the AI model is kept **confidential at all times**. Neither the AI service provider nor the Cloud provider (if applicable), can see the data. 
-Confidentiality is assured by hardware-enforced [**Trusted Execution Environments**](--LINK CC EXPLAINED or DOC). We explain how they keep data and models safe in detail [here](--LIEN PRIVACY).
+Confidentiality is assured by hardware-enforced [**Trusted Execution Environments**](). We explain how they keep data and models safe in detail [here]().
 
 **BlindAi is an open-source project** consisting of:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,16 +97,24 @@ markdown_extensions:
 # Documentation tree
 nav:
 - 🏠 Home: 'index.md' 
+
 - 🚀 Getting Started: 
   - Why BlindAI: "docs/getting-started/why-blindai.md"
   - Quick tour: "docs/getting-started/quick-tour.ipynb"
   - Installation: "docs/getting-started/installation.md"
+
 - 💡 Main concepts:
   - 'docs/main-concepts/overview.md'
   - 'Trusting BlindAI':
     - 'docs/main-concepts/privacy.md'
     - 'docs/main-concepts/attestation.md'
     - 'docs/main-concepts/tls.md'
+
+- 🛠️ Client API reference: 'blindai_preview/client.html'
+
+- 🔒 Security:
+  - 'docs/advanced/security/remote_attestation.md'
+  - 'docs/advanced/security/threat_model.md'
 
 - 'Advanced':
   - 'Build from sources':
@@ -118,11 +126,6 @@ nav:
   #   - Setting-up your dev environment: 'docs/advanced/contributing/setting-up-your-dev-environment.md'
   #   - Contributing: "docs/advanced/contributing/contributing.md"
   #   - Code of Conduct: "docs/advanced/contributing/code_of_conduct.md"
-
-- 🔒 Security:
-  - 'docs/advanced/security/remote_attestation.md'
-  - 'docs/advanced/security/threat_model.md'
-- 🛠️ Client API reference: 'blindai_preview/client.html'
 
 # - 'Integrating AI models from other frameworks':
 #   - 'Example of BlindAI deployment with ResNet18': 'BlindAI_ResNet18.ipynb'


### PR DESCRIPTION
QUICK-TOUR.IPYNB
- Pushed the reader to click on Google Colab more in the Quick Tour 
- Reduced the Quick Tour intro which has been extended(?) while keeping the added ideas

MKDOCS.YML
- Pushed Security and the API navigation a bit up (unless there was a reason they were in that order) 

INSTALLATION.MD
- Moved the testing option in the install guide to the top. It doesn't make sense for it to be all the way down because that IS the first thing people will use even if it's only for testing and not the right thing for production. It also promotes the Quick Tour which is what we want mainly so... yeah I think it's better. 