### PR TITLE
Fix CI to make it less flaky

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ jobs:
         fi
         git checkout -b "$branch" || true
     - name: Download latest earthly
-      run: "wget -nc https://github.com/earthly/earthly/releases/download/v0.6.30/earthly-linux-amd64 -O earthly && chmod +x earthly"
+      run: "wget -nc https://github.com/earthly/earthly/releases/download/v0.7.2/earthly-linux-amd64 -O earthly && chmod +x earthly"
     - name: Earthly version
       run: ./earthly --version
     - name: Run build

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+
+members = ["remote_attestation_sgx"]
+
 [package]
 name = "runner"
 version = "0.1.0"


### PR DESCRIPTION
* Circumvent a "bug" in Cargo which causes Cargo not to rebuild in some cases
* Add a reproducibility check as part of CD
* Upgrade to Earthly 7.2
* Put the runner and remote_attestation_sgx crates in a common Cargo workspace