### PR TITLE
Ophelie navigation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ BlindAI facilitates  **privacy-friendly AI model deployment** by letting AI engi
 
 Data sent by users to the AI model is kept **confidential at all times**. Neither the AI service provider nor the Cloud provider (if applicable), can see the data.
 
-Confidentiality is assured by hardware-enforced [**Trusted Execution Environments**](--LINK CC EXPLAINED or DOC). We explain how they keep data and models safe in detail [here](./docs/docs/main-concepts/privacy.md).
+Confidentiality is assured by hardware-enforced **Trusted Execution Environments**. We explain how they keep data and models safe in detail [here](./docs/docs/concepts/privacy.md).
 
 ### Built With 
 

--- a/docs/docs/advanced/build-from-sources/server.md
+++ b/docs/docs/advanced/build-from-sources/server.md
@@ -125,7 +125,7 @@ The manifest will be generated at the build process and will serve as essential 
 * `manifest.toml`: the enclave security manifest that defines which enclave is trusted.
 
 
-More informations about them on [this page](../../main-concepts/privacy.md) and in the [remote attestation implementation](../security/remote_attestation.md).
+More informations about them on [this page](../../concepts/privacy.md) and in the [remote attestation implementation](../security/remote_attestation.md).
 
 ### Running
 

--- a/docs/docs/concepts/attestation.md
+++ b/docs/docs/concepts/attestation.md
@@ -1,12 +1,15 @@
 # Attesting a BlindAI enclave
+__________________________________________
 
 How does a client know that he is communicating with an authentic enclave, and how does he know it's the right one?
 
 ## Verifying the hardware
+__________________________________________
 
 When communicating with the client, the enclave issues its signed, hardware-backed, attestation. Using the intel public key the client can eventually assess that he is communicating with a secure enclave powered by an up-to-date Intel SGX CPU. The process is in reality a lot more complex than that, and [this paper](https://eprint.iacr.org/2016/086.pdf) explains these concepts much more in-depth. Note however that BlindAI's goal is to abstract these complicated processes while keeping the same privacy guarantees.
 
 ## Verifying the enclave
+__________________________________________
 
 The enclave building process will generate a manifest file that contains a hash of the compilation process and some attributes like debug mode, authorized instructions and so on. This is also referred as the MRENCLAVE and it is sufficient to safely authenticate an enclave. In BlindAI's case, each time our client interacts with our server, the server gives out its MRENCLAVE so that the client can compare it against the manifest file passed by the user. This way he can attest that the secure enclave he is connected to is running the right code, with the right options.
 
@@ -18,8 +21,8 @@ If you want to modify the server, you will need to override the Manifest file.To
 
 The client handles this verification process so you only have to make sure that the client gets the correct manifest file. If the client connects, it means the remote enclave is compliant to the enclave description from the Manifest.
 
-
 ## Reproduce the enclave binary
+__________________________________________
 
 The enclave binary and the corresponding manifest are built using this [dockerfile](https://github.com/mithril-security/blindai-preview/blob/main/.github/sgxs-release.dockerfile). You can inspect the dockerfile and run it to build the artifacts using the following commands :
 ```bash
@@ -30,9 +33,8 @@ docker cp "$id:/blindai-preview/manifest.toml" .
 docker rm -v $id
 ```
 
-
-
 ## Try it for yourself
+__________________________________________
 
 If you want to test the authenticating property of the MRENCLAVE, you can do the following:
 

--- a/docs/docs/concepts/overview.md
+++ b/docs/docs/concepts/overview.md
@@ -1,17 +1,5 @@
 # Overview
-
-## What is Blindai?
-
-BlindAI is a confidential AI inference server. Like regular AI inference solutions, BlindAI helps AI engineers serve models for end-users to benefit from their predictions, but with an added privacy layer. Data sent by users to the AI model is kept confidential at all times, from the transfer to the analysis. This way, users can benefit from AI models without ever having to expose their data in the clear to anyone: neither the AI service provider nor the Cloud provider (if any), can see the data.
-
-Confidentiality is assured by using special hardware-enforced Trusted Execution Environments. More explanations about them in [this section](privacy.md).
-
-Our solution comes in two parts:
-
-- A secure inference server to serve AI models with privacy guarantees, developed using the Rust Programming Language.
-- A Python client SDK to securely consume the remote AI models.
-
-![](../../assets/With_and_without_blindai.gif)
+________________________________________
 
 BlindAI workflow is simple:
 
@@ -20,6 +8,7 @@ BlindAI workflow is simple:
 - [Prediction](../../index.md): Once remote attestation passes, the client can send data to be safely analyzed using a TLS channel that ends inside the enclave. The AI model can be uploaded and applied, then the result is sent securely.
 
 ## Features
+____________________________________________________
 
 * Simple and fast API to use the service
 * Model and data protected by hardware security
@@ -37,7 +26,3 @@ BlindAI workflow is simple:
 * Our solution aims to be modular but we have yet to incorporate tools for generic pre/post-processing. Specific pipelines can be covered but will require additional handwork for now.
 * BlindAI does not cover training or federated learning, however you can check our [roadmap](https://github.com/mithril-security/blindai/projects/1) or [Discord](https://discord.gg/TxEHagpWd4) channel to know more about what we are working on and solutions.
 * The examples we provide are simple and do not take into account complex mechanisms such as secure storage of confidential data with sealing keys, an advanced scheduler for inference requests, or complex key management scenarios. If your use case involves more than what we show, do not hesitate to **contact us** for more information.
-
-## Who made BlindAI?&#x20;
-
-BlindAI was developed by **Mithril Security**. **Mithril Security** is a startup focused on confidential machine learning based on **Intel SGX** technology. We provide an **open-source AI inference solution**, **allowing easy and fast deployment of neural networks, with strong security properties** provided by confidential computing by performing the computation in a hardware-based **Trusted Execution Environment** (_TEE_) or simply **enclaves**.

--- a/docs/docs/concepts/privacy.md
+++ b/docs/docs/concepts/privacy.md
@@ -1,14 +1,17 @@
 # Ensuring privacy with BlindAI
+__________________________________________
 
 In this section, we will explain how BlindAI secures its users' data and what you should do to secure your models and your data using BlindAI.
 
 ## What is confidential computing ?
+__________________________________________
 
 Confidential computing refers to the technology that can isolate a process within a protected CPU. During its execution, the program runs into a **TEE** (Trusted Execution Environment). This is because nobody, not even the machine owner, can access in any way this environment, meaning that any sensible data, the source code, and the program computations are isolated.
 
 To achieve this we are relying on Intel SGX enabled CPUs. These CPUs have the ability to start a **Secure Enclave**, which is another way to say that it can execute code inside a TEE.
 
 ## Trusting BlindAI
+__________________________________________
 
 As a user wanting privacy guarantees, here is a step-by-step list of what you should do to securely deploy or connect to BlindAI:
 

--- a/docs/docs/concepts/tls.md
+++ b/docs/docs/concepts/tls.md
@@ -1,10 +1,13 @@
 # Securely communicating with BlindAI
+__________________________________________
 
 ## A Reverse-proxy for the Unsecure port 
+__________________________________________
 
 The unsecure port was made to run only on HTTP. For that case, we highly recommand placing a reverse-proxy, that takes care of the TLS encryption for the unsecure port 9923 between the client and the server. 
 
 ## How to choose
+__________________________________________
 
 Multiple reverse-proxies that are usable with are available in use. 
 Apache, Nginx and Caddy are good examples. 

--- a/docs/docs/security/threat_model.md
+++ b/docs/docs/security/threat_model.md
@@ -1,10 +1,11 @@
-# Threat Model : BlindAI 
-
-## 1. Introduction 
+# Threat model
+__________________________________________
 
 This document provides the threat model for **BlindAI using the Intel SGX platform and fortanix EDP**. 
 
-## 2. Target Evaluation 
+## Target Evaluation 
+__________________________________________
+
 In this threat model, the target of evaluation is the BlindAI code (using the fortanix EDP), server side **(TC1)** and client side **(TC2)**, the fortanix EDP platform **(TC3)**, the Intel SGX platform **(TC4)**, the SDK and software related to SGX DCAP (which includes AESM, the PCCS service and the intel-sgx SDK) **(TC5)**. 
 *TC for target component notation*.
 
@@ -21,7 +22,9 @@ To achieve that configuration, we make the following assumptions :
 - We consider the data and model sent by the client to the server to be trusted, as he is the one that owns it. 
 - The issues concerning the guarantee of the availability of the SGX platform and hence the BlindAi App are not taken into consideration and are out of scope. 
 
-## 3. Data Flow Diagram
+## Data Flow Diagram
+__________________________________________
+
 The figure below shows a high-level data flow diagram for the BlindAI app. The diagram shows a model of the different components that interacts to achieve the remote attestation process and running the models as an inference engine. 
 
 - the red lines present the insecure connections. 
@@ -43,7 +46,9 @@ The figure below shows a high-level data flow diagram for the BlindAI app. The d
 | **DF8**   | Create a new TLS connection, this one using the information exchanged |  
 | **DF9**   | Begin exchanging the data through the secure TLS connection to be processed by the enclave |
 
-## 4. Threat Analysis 
+## Threat Analysis 
+__________________________________________
+
 In this section we provide an assessment of the potential threats to the BlindAI app while indentifying the different dependencies used and possible vectors of foothold. 
 
 For each threat, we identify the *asset* that is under threat, the *threat agent*, and the *threat type*. 
@@ -51,7 +56,7 @@ For each threat, we identify the *asset* that is under threat, the *threat agent
 Each threat is also given a *risk rating* that represent the impact and likelihood of that threat, and potential mitigations are also provided accordingly. 
 
 
-### 4.1. Assets 
+### Assets 
 
 | Asset | Description |
 | ----- | ----------- |
@@ -62,7 +67,8 @@ Each threat is also given a *risk rating* that represent the impact and likeliho
 | ***Availability*** | This represents the availability of the BlindAI app through it's use. |
 
 
-### 4.2. Threat Agents 
+### Threat Agents 
+
 The threat agents represents the possible entry points that may be used by potential attackers. 
 
 
@@ -72,11 +78,12 @@ The threat agents represents the possible entry points that may be used by poten
 | SecCode | Represent the malicious or faulty code running on the secure world, i.e. the SGX enclave. It includes the blindAI code running inside the enclave and the related dependencies (Fortanix API, and code dependencies). |
 
 
-### 4.3. Threat Types
+### Threat Types
+
 In this Threat Model we categorize the threats using the ***STRIDE Threat analysis technique***. Thus, a threat is categorized as one or more of these types: 
 `spoofing`, `Tampering`, `Repudiation`, `Information Disclosure`, `Denial of Service`, `Privilege Escalation`. 
 
-### 4.4. Threat Risk Ratings
+### Threat Risk Ratings
 
 For each threat identified, a risk rating that ranges from *informational* to *critical* is given based on the the likelihood of the threat occurring if a mitigation is not in place and the impact of the threat (i.e. how severely the assets are affected).
 
@@ -101,7 +108,7 @@ From the standard risk assessment level documentation, the below table represent
 | Informational | 1             |
 
 
-### 4.5. Threat Assessment
+### Threat Assessment
 <br />
 
 | ID &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | 01 &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;|

--- a/docs/docs/tutorials/api/whisper-audio.ipynb
+++ b/docs/docs/tutorials/api/whisper-audio.ipynb
@@ -5,7 +5,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# BlindAi Whisper Integration\n",
+    "# Whisper Integration\n",
+    "_______________________________________________\n",
     "\n",
     "Speech recognition has become a crucial aspect of our everyday lives because to technological advancements, from virtual assistants like Siri and Alexa to transcribing services used in business and academics. Whisper is a state-of-the-art voice recognition API that takes advantage of the most recent developments in AI and machine learning to offer extremely accurate and effective transcription services.\n",
     "\n",
@@ -18,11 +19,12 @@
    "metadata": {},
    "source": [
     "## Pre-requisites\n",
+    "________________________________________________________\n",
     "\n",
     "Before we begin, you will need to install these Python libraries:\n",
     "\n",
-    "- [blindai-preview] (https://pypi.org/project/blindai-preview/)\n",
-    "- [gdown] (https://pypi.org/project/gdown/)\n",
+    "- [blindai-preview](https://pypi.org/project/blindai-preview/)\n",
+    "- [gdown](https://pypi.org/project/gdown/)\n",
     "- [Test Audio File](https://github.com/openai/whisper/raw/main/tests/jfk.flac)"
    ]
   },
@@ -79,7 +81,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Transcribing Audio with BlindAI Whisper\n",
+    "## Transcribing Audio\n",
+    "______________________________________________\n",
     "\n",
     "BlindAI internally handles connection to the managed cloud solution which has an instance of the BlindAI server running.\n",
     "\n",

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ ________________________________________________________
 - Follow our [“Quick tour”](./docs/getting-started/quick-tour.ipynb) tutorial
 - Read about [why you should use](./docs/getting-started/why-blindai.md) BlindAI
 - Explore our [installation guide](./docs/getting-started/installation.md)
-- [Tackle](./docs/advanced/security/remote_attestation.md) the technologies we use to ensure privacy
+- [Tackle](./docs/security/remote_attestation.md) the technologies we use to ensure privacy
 
 ## Getting help
 ________________________________________________________
@@ -51,7 +51,7 @@ ____________________________________________
 
 - [API Reference](https://blindai-preview.mithrilsecurity.io/en/latest/blindai_preview/client.html) contains technical references for BlindAI’s API machinery. They describe how it works and how to use it but assume you have a good understanding of key concepts.
 
-- [Security](./docs/advanced/security/remote_attestation/) guides contain technical information for security engineers. They explain the threat models and other cybersecurity topics required to audit BlindAI's security standards.
+- [Security](./docs/security/remote_attestation/) guides contain technical information for security engineers. They explain the threat models and other cybersecurity topics required to audit BlindAI's security standards.
 
 - [Advanced](./docs/advanced/build-from-sources/client/) guides are destined to developpers wanting to dive deep into BlindAI and eventually collaborate with us to the open-source code. 
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -25,7 +25,7 @@
 
 /****** Tweaking the navigation sections style only on Desktop ******/
 
-@media screen and (min-width: 1025px) {
+@media screen and (min-width: 1200px) {
 
 	/* rules to style all level 0 navigation titles */
 	nav[data-md-level="0"]>ul>li>.md-nav__link {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,10 +105,10 @@ nav:
   - Quick tour: "docs/getting-started/quick-tour.ipynb"
 
 - Tutorials:
-  - BlindAI API:
-    - Whisper integration: 'docs/tutorials/api/whisper-audio.ipynb'
-  - BlindAI Core:
-    - Installation: "docs/getting-started/installation.md"
+# - BlindAI API:
+#    - Whisper integration: 'docs/tutorials/api/whisper-audio.ipynb'
+#  - BlindAI Core:
+  - Installation: "docs/getting-started/installation.md"
 #    - Uploading models:
 
 - 💡 Concepts:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,40 +100,38 @@ nav:
 
 - 🚀 Getting Started: 
   - Why BlindAI: "docs/getting-started/why-blindai.md"
+# - BlindAI API VS BlindAI Core: 'quick presentation'
   - Quick tour: "docs/getting-started/quick-tour.ipynb"
-  - Installation: "docs/getting-started/installation.md"
 
-- 💡 Main concepts:
-  - 'docs/main-concepts/overview.md'
-  - 'Trusting BlindAI':
-    - 'docs/main-concepts/privacy.md'
-    - 'docs/main-concepts/attestation.md'
-    - 'docs/main-concepts/tls.md'
+- Tutorials:
+  - BlindAI API:
+    - Whisper integration: 'docs/tutorials/api/whisper-audio.ipynb'
+  - BlindAI Core:
+    - Installation: "docs/getting-started/installation.md"
+#    - Uploading models:
 
-- 'How-to-Guides':
-  - 'docs/how-to-guides/whisper-audio.ipynb'
+- 💡 Concepts:
+  - Overview: 'docs/main-concepts/overview.md'
+  - Privacy: 'docs/main-concepts/privacy.md'
+  - Attestation: 'docs/main-concepts/attestation.md'
+  - TLS: 'docs/main-concepts/tls.md'
+
+#- 🌍 How-to-Guides:
+  # - Using BlindAI Core in a real life scenario / to solve a problem
 
 - 🛠️ Client API reference: 'blindai_preview/client.html'
 
 - 🔒 Security:
-  - 'docs/advanced/security/remote_attestation.md'
-  - 'docs/advanced/security/threat_model.md'
+  - Remote attestation: 'docs/advanced/security/remote_attestation.md'
+  - Threat model: 'docs/advanced/security/threat_model.md'
 
-- 'Advanced':
-  - 'Build from sources':
-    - 'docs/advanced/build-from-sources/client.md'
-    - 'docs/advanced/build-from-sources/server.md'
+- ⚙️ Advanced:
+  - Build from sources:
+    - Client SDK: 'docs/advanced/build-from-sources/client.md'
+    - Server: 'docs/advanced/build-from-sources/server.md'
   # - Telemetry: 'docs/telemetry.md'
   # - Open source:
   #   - Project structure: 'docs/advanced/contributing/blindai-project-structure.md'
   #   - Setting-up your dev environment: 'docs/advanced/contributing/setting-up-your-dev-environment.md'
   #   - Contributing: "docs/advanced/contributing/contributing.md"
   #   - Code of Conduct: "docs/advanced/contributing/code_of_conduct.md"
-
-# - 'Integrating AI models from other frameworks':
-#   - 'Example of BlindAI deployment with ResNet18': 'BlindAI_ResNet18.ipynb'
-#   - 'Example of BlindAI deployment with CovidNet': 'BlindAI-COVID-Net.ipynb'
-#   - 'Example of BlindAI deployment with DistilBERT': 'BlindAI-DistilBERT.ipynb'
-#   - 'Example of BlindAI deployment with Facenet': 'BlindAI-Facenet.ipynb'
-#   - 'Example of BlindAI deployment with Wav2vec2': 'BlindAI-Wav2vec2.ipynb'
-#   - 'Example of BlindAI deployement with Whisper': 'BlindAI_Whisper.ipynb'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ theme:
     - navigation.sections
     - navigation.indexes
     - navigation.expand
+    
   logo: assets/logo.png
   favicon: assets/logo.png
   palette:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,10 +112,10 @@ nav:
 #    - Uploading models:
 
 - 💡 Concepts:
-  - Overview: 'docs/main-concepts/overview.md'
-  - Privacy: 'docs/main-concepts/privacy.md'
-  - Attestation: 'docs/main-concepts/attestation.md'
-  - TLS: 'docs/main-concepts/tls.md'
+  - Overview: 'docs/concepts/overview.md'
+  - Privacy: 'docs/concepts/privacy.md'
+  - Attestation: 'docs/concepts/attestation.md'
+  - TLS: 'docs/concepts/tls.md'
 
 #- 🌍 How-to-Guides:
   # - Using BlindAI Core in a real life scenario / to solve a problem
@@ -123,8 +123,8 @@ nav:
 - 🛠️ Client API reference: 'blindai_preview/client.html'
 
 - 🔒 Security:
-  - Remote attestation: 'docs/advanced/security/remote_attestation.md'
-  - Threat model: 'docs/advanced/security/threat_model.md'
+  - Remote attestation: 'docs/security/remote_attestation.md'
+  - Threat model: 'docs/security/threat_model.md'
 
 - ⚙️ Advanced:
   - Build from sources:


### PR DESCRIPTION
**MKDOCS.YML**
cleaned up the navigation et reorganised some stuff so it makes more sense

**WHISPER INTEGRATION**
Didn't change much - IF we keep it, I'll need to go over it more in another PR.

**OVERVIEW**
Got rid of the redundant parts

**SECURITY & CONCEPTS**
Moved threat model and remote attestation into the proper file + changed main-concepts to concepts. Changed appropriate links

**PRETTIED UP many files a little bit. Shallow editing/formatting**

