### PR TITLE
BlindAI Telemetry Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,7 @@ dependencies = [
  "tract-onnx",
  "ureq",
  "uuid",
+ "webpki",
  "webpki-roots",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,7 @@ dependencies = [
  "rcgen",
  "ring",
  "rouille",
+ "rustls",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -113,6 +114,7 @@ dependencies = [
  "tract-onnx",
  "ureq",
  "uuid",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -503,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-sink"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,11 @@ serde_bytes = "0.11.8"
 tiny_http = { path = "tiny-http" }
 cfg-if = "1.0.0"
 lazy_static = "1.4.0"
+# These libraries help to create a custom DNS resolver when making 
+# reqs out of the enclave.
 webpki-roots = "0.22.6"
-rustls = "0.20.8"
+rustls = {version="0.20.8", features=["dangerous_configuration"]}
+webpki = "0.22.0"
 
 [dev-dependencies]
 image = "0.24.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,13 @@ tract-hir = {path="tract/hir"}  #{version = "0.17.2-pre"}
 # ssl feature is patched to enable TLS support via rustls
 rouille = { path = "rouille", features = ["ssl"] }
 sgx-isa = { version = "0.4.0", features = ["serde"] }
-ureq = {version = "2.5.0", features = ["json"]}
+ureq = {version = "2.5.0", features = ["json", "rustls"]}
 serde_bytes = "0.11.8"
 tiny_http = { path = "tiny-http" }
 cfg-if = "1.0.0"
 lazy_static = "1.4.0"
+webpki-roots = "0.22.6"
+rustls = "0.20.8"
 
 [dev-dependencies]
 image = "0.24.1"

--- a/client/blindai_preview/client.py
+++ b/client/blindai_preview/client.py
@@ -650,10 +650,10 @@ class BlindAiConnection(contextlib.AbstractContextManager):
             repeatedly to determine whether or not a particular example is part of the trained dataset model.
         Args:
             model (str): Path to Onnx model file.
-            model_name (Optional[str], optional): Name of the model. By default, the server will assign a random UUID.
-                You can call the model with the name you specify here.
+            model_name (Optional[str], optional): Name of the model.
+                Used for you to identify the model, but won't be used by the server (a random UUID will be assigned to your model for the inferences).
             optimize (bool): Whether tract (our inference engine) should optimize the model or not.
-                Optimzing should only be turned off when tract wasn't able to optimze the model.
+                Optimzing should only be turned off when you are encountering issues loading your model.
         Raises:
             HttpError: raised by the requests lib to relay server side errors
             ValueError: raised when inputs sanity checks fail
@@ -757,8 +757,7 @@ class BlindAiConnection(contextlib.AbstractContextManager):
         only be present in memory, and will disappear when the server close.
 
         **Security & confidentiality warnings: **
-            model_id: If you are using this on the Mithril Security Cloud, you can only delete models
-            that you uploaded. Otherwise, the deletion of a model does only relies on the `model_id`.
+            model_id: The deletion of a model does only relies on the `model_id`.
             It doesn't relies on a session token or anything, hence if the `model_id` is known,
             it's deletion is possible.
 

--- a/client/blindai_preview/client.py
+++ b/client/blindai_preview/client.py
@@ -38,8 +38,7 @@ from requests.adapters import HTTPAdapter
 from importlib_metadata import version
 import warnings
 
-# app_version = version("blindai-preview")
-app_version = "0.0.dev"
+app_version = version("blindai-preview")
 
 CONNECTION_TIMEOUT = 10
 

--- a/runner/Cargo.lock
+++ b/runner/Cargo.lock
@@ -1530,6 +1530,7 @@ dependencies = [
  "env_logger",
  "remote_attestation_sgx",
  "sgxs-loaders",
+ "whoami",
 ]
 
 [[package]]
@@ -2243,6 +2244,16 @@ dependencies = [
  "either",
  "libc",
  "once_cell",
+]
+
+[[package]]
+name = "whoami"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c70234412ca409cc04e864e89523cb0fc37f5e1344ebed5a3ebf4192b6b9f68"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -15,3 +15,4 @@ enclave-runner = "0.5.1"
 sgxs-loaders = "0.3.3"
 remote_attestation_sgx = {path = "remote_attestation_sgx/"}
 env_logger = "0.10.0"
+whoami = "1.4.0"

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -1,7 +1,11 @@
 use aesm_client::AesmClient;
 use enclave_runner::EnclaveBuilder;
 use sgxs_loaders::isgx::Device as IsgxDevice;
-use std::thread;
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+    thread,
+};
 
 fn usage(name: String) {
     println!("Usage: \n{name} <path_to_sgxs_file>");
@@ -23,6 +27,17 @@ fn main() {
     // Running the remote attestation thread
     let remote_att_sgx = thread::spawn(remote_attestation_sgx::start_remote_attestation);
 
+    // Extracting platform and uid from whoami
+    let sgx_mode = if cfg!(target_env = "sgx") { "HW" } else { "SW" };
+    let platform = format!("{} - {}", whoami::platform(), sgx_mode);
+    let uid = {
+        let mut hasher = DefaultHasher::new();
+        whoami::username().hash(&mut hasher);
+        whoami::hostname().hash(&mut hasher);
+        platform.hash(&mut hasher);
+        format!("{:X}", hasher.finish())
+    };
+    let custom_agent_id = std::env::var("CUSTOM_AGENT_ID").unwrap_or_default();
     // Running the enclave
     let file = parse_args().unwrap();
     let aesm_client = AesmClient::new();
@@ -30,7 +45,19 @@ fn main() {
         .unwrap()
         .einittoken_provider(aesm_client)
         .build();
-    let enclave_builder = EnclaveBuilder::new(file.as_ref());
+    let mut enclave_builder = EnclaveBuilder::new(file.as_ref());
+
+    fn make_arg(arg_name: &str, arg_value: &str) -> Vec<u8> {
+        let mut arg = arg_name.as_bytes().to_vec();
+        arg.push(b'=');
+        arg.extend_from_slice(arg_value.as_bytes());
+        arg
+    }
+    enclave_builder.args([
+        make_arg("--uid", &uid),
+        make_arg("--platform", &platform),
+        make_arg("--custom_agent_id", &custom_agent_id),
+    ]);
 
     let enclave = enclave_builder.build(&mut device).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use model_store::ModelStore;
 mod client_communication;
 use lazy_static::lazy_static;
 use log::debug;
+mod telemetry;
 
 // ra
 use env_logger::Env;
@@ -32,6 +33,7 @@ use ring::digest;
 use serde::{Deserialize, Serialize};
 use serde_bytes::Bytes;
 use sgx_isa::{Report, Targetinfo};
+use telemetry::Telemetry;
 
 #[derive(Serialize)]
 struct GetQuoteRequest {
@@ -49,6 +51,7 @@ lazy_static! {
         1_000_000_000,
         1_000_000,
     ));
+    pub static ref TELEMETRY_CHANNEL: Arc<Telemetry> = Arc::new(Telemetry::new().unwrap());
 }
 
 // "Native" Rust type for sgx_ql_qve_collateral_t
@@ -92,6 +95,19 @@ fn get_collateral(quote: &[u8]) -> Result<SgxCollateral> {
 
 fn main() -> Result<()> {
     println!("BlindAI server is running on the ports 9923 and 9924");
+
+    // Setup TELEMETRY
+    let telemetry_disabled = TELEMETRY_CHANNEL.is_disabled();
+    let telemetry_disabled_string = format!(
+        "BlindAI telemetry is {}",
+        if telemetry_disabled {
+            "disabled"
+        } else {
+            "enabled"
+        }
+    );
+
+    println!("{}", telemetry_disabled_string);
 
     const SERVER_NAME: &str = if cfg!(target_env = "sgx") {
         "blindai_preview"
@@ -274,6 +290,9 @@ fn main() -> Result<()> {
             _trusted_handle.join().unwrap();
         }
     });
+
+    // Emit the telemetry `Started` event
+    telemetry::add_event(telemetry::TelemetryEventProps::Started {}, None, None);
     _unattested_handle.join().unwrap();
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,8 @@ mod client_communication;
 use lazy_static::lazy_static;
 use log::debug;
 mod telemetry;
+mod ureq_dns_resolver;
+use telemetry::Telemetry;
 
 // ra
 use env_logger::Env;
@@ -33,7 +35,6 @@ use ring::digest;
 use serde::{Deserialize, Serialize};
 use serde_bytes::Bytes;
 use sgx_isa::{Report, Targetinfo};
-use telemetry::Telemetry;
 
 #[derive(Serialize)]
 struct GetQuoteRequest {
@@ -107,7 +108,7 @@ fn main() -> Result<()> {
         }
     );
 
-    println!("{}", telemetry_disabled_string);
+    println!("{telemetry_disabled_string}");
 
     const SERVER_NAME: &str = if cfg!(target_env = "sgx") {
         "blindai_preview"

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -160,7 +160,7 @@ pub fn setup() -> anyhow::Result<bool> {
         }
 
         if !events.is_empty() {
-            let agent = InternalAgent::new(TELEMETRY_IP, "443");
+            let agent = InternalAgent::new(TELEMETRY_IP, "443", &["telemetry.mithrilsecurity.io"]);
             let response = agent.post(TELEMETRY_URL).send_json(&events);
 
             if let Err(e) = response {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,280 @@
+use crate::client_communication::ClientInfo;
+use crate::identity::create_tls_certificate;
+use crate::TELEMETRY_CHANNEL;
+use rustls::version::{TLS12, TLS13};
+use serde::Serialize;
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use ureq::Agent;
+
+#[derive(Debug, Clone, Serialize)]
+pub enum TelemetryEventProps {
+    Started {},
+    SendModel {
+        model_name: Option<String>,
+        model_size: usize,
+        // sign: bool, Used when we will support signed models
+        time_taken: f64,
+    },
+    RunModel {
+        model_hash: Option<String>,
+        // sign: bool, Used when we will support signed models
+        time_taken: f64,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct TelemetryEvent {
+    event_type: &'static str,
+    props: TelemetryEventProps,
+    time: SystemTime,
+    client_info: Option<ClientInfo>,
+    cloud_user_id: Option<usize>,
+}
+
+impl TelemetryEventProps {
+    fn event_type(&self) -> &'static str {
+        match self {
+            TelemetryEventProps::Started {} => "started",
+            TelemetryEventProps::SendModel { .. } => "send_model",
+            TelemetryEventProps::RunModel { .. } => "run_model",
+        }
+    }
+}
+
+pub(crate) fn add_event(
+    event: TelemetryEventProps,
+    client_info: Option<ClientInfo>,
+    cloud_user_id: Option<usize>,
+) {
+    let channel = TELEMETRY_CHANNEL.get_sender();
+    if let Some(sender) = channel {
+        let sender = sender.lock().unwrap();
+        let _ = sender.send(TelemetryEvent {
+            event_type: event.event_type(),
+            props: event,
+            time: SystemTime::now(),
+            client_info,
+            cloud_user_id,
+        });
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct RequestEvent<'a> {
+    user_id: &'a str,
+    cloud_user_id: Option<usize>,
+    custom_agent_id: Option<&'a str>,
+    event_type: &'a str,
+    device_id: &'a str,
+    time: u64,
+    app_version: &'a str,
+    user_properties: ReqestUserProperties<'a>,
+    event_properties: Option<&'a TelemetryEventProps>,
+}
+
+#[derive(Debug, Serialize, Default)]
+struct ReqestUserProperties<'a> {
+    sgx_mode: &'a str,
+    uptime: u64,
+    azure_dcsv3_patch_enabled: bool,
+    client_uid: Option<&'a str>,
+    client_platform_name: Option<&'a str>,
+    client_platform_arch: Option<&'a str>,
+    client_platform_version: Option<&'a str>,
+    client_platform_release: Option<&'a str>,
+    client_user_agent: Option<&'a str>,
+    client_user_agent_version: Option<&'a str>,
+}
+
+pub fn get_agent() -> Agent {
+    let mut root_store = rustls::RootCertStore::empty();
+
+    // This adds webpki_roots certs.
+    root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+        rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
+            ta.subject,
+            ta.spki,
+            ta.name_constraints,
+        )
+    }));
+
+    // This is how we narrow down the allowed TLS versions for rustls.
+    let protocol_versions = &[&TLS12, &TLS13];
+
+    // See rustls documentation for more configuration options.
+    let tls_config = rustls::ClientConfig::builder()
+        .with_safe_default_cipher_suites()
+        .with_safe_default_kx_groups()
+        .with_protocol_versions(protocol_versions)
+        .unwrap()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+
+    // Build a ureq agent with the rustls config.
+    ureq::builder().tls_config(Arc::new(tls_config)).build()
+}
+
+pub fn setup() -> anyhow::Result<bool> {
+    let sgx_mode = if cfg!(SGX_MODE = "HW") { "HW" } else { "SW" };
+    let azure_dcsv3_patch_enabled = std::env::var("BLINDAI_AZURE_DCSV3_PATCH").is_ok();
+
+    let first_start = SystemTime::now();
+
+    thread::spawn(move || loop {
+        let receiver = TELEMETRY_CHANNEL.get_receiver().unwrap();
+        let custom_agent_id = TELEMETRY_CHANNEL.get_custom_agent_id();
+        let uid = TELEMETRY_CHANNEL.get_uid().unwrap_or(String::default());
+        let platform = TELEMETRY_CHANNEL
+            .get_platform()
+            .unwrap_or(String::default());
+        let receiver = receiver.lock().unwrap();
+
+        let mut received_events = Vec::new();
+        let mut events = Vec::new();
+        while let Ok(properties) = receiver.try_recv() {
+            received_events.push(properties);
+        }
+
+        for properties in &received_events {
+            let mut user_properties = ReqestUserProperties {
+                uptime: properties
+                    .time
+                    .duration_since(first_start)
+                    .unwrap()
+                    .as_secs(),
+                sgx_mode,
+                azure_dcsv3_patch_enabled,
+                ..Default::default()
+            };
+
+            if let Some(ref client_info) = properties.client_info {
+                user_properties.client_uid = Some(client_info.uid.as_ref());
+                user_properties.client_platform_name = Some(client_info.platform_name.as_ref());
+                user_properties.client_platform_arch = Some(client_info.platform_arch.as_ref());
+                user_properties.client_platform_version =
+                    Some(client_info.platform_version.as_ref());
+                user_properties.client_platform_release =
+                    Some(client_info.platform_release.as_ref());
+                user_properties.client_user_agent = Some(client_info.user_agent.as_ref());
+                user_properties.client_user_agent_version =
+                    Some(client_info.user_agent_version.as_ref());
+            }
+
+            let event_type = properties.event_type;
+            let (user_id, device_id, app_version) =
+                (uid.as_ref(), platform.as_ref(), env!("CARGO_PKG_VERSION"));
+
+            let event = RequestEvent {
+                user_id,
+                event_type,
+                device_id,
+                cloud_user_id: properties.cloud_user_id,
+                custom_agent_id,
+                time: properties
+                    .time
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+                app_version,
+                user_properties,
+                event_properties: Some(&properties.props),
+            };
+
+            events.push(event);
+        }
+
+        if !events.is_empty() {
+            let agent = get_agent();
+            let response = agent
+                .post("https://telemetry.mithrilsecurity.io/blindai")
+                .send_json(&events);
+
+            println!("Response: {:?}", response);
+            if let Err(e) = response {
+                log::debug!("Cannot contact telemetry server: {}", e);
+            }
+        };
+        thread::sleep(Duration::from_secs(5));
+    });
+    Ok(false)
+}
+
+pub struct Telemetry {
+    disabled: bool,
+    sender: Option<Arc<Mutex<Sender<TelemetryEvent>>>>,
+    receiver: Option<Arc<Mutex<Receiver<TelemetryEvent>>>>,
+    custom_agent_id: Option<String>,
+    platform: Option<String>,
+    uid: Option<String>,
+}
+
+impl Telemetry {
+    pub fn new() -> anyhow::Result<Self> {
+        let telemetry_disabled = std::env::var("BLINDAI_DISABLE_TELEMETRY").is_ok()
+            || std::env::var("DO_NOT_TRACK").is_ok();
+
+        let init = if telemetry_disabled {
+            Self {
+                disabled: true,
+                sender: None,
+                receiver: None,
+                custom_agent_id: None,
+                platform: None,
+                uid: None,
+            }
+        } else {
+            let (sender, receiver) = mpsc::channel::<TelemetryEvent>();
+
+            setup()?;
+            Self {
+                disabled: false,
+                sender: Some(Arc::new(Mutex::new(sender))),
+                receiver: Some(Arc::new(Mutex::new(receiver))),
+                custom_agent_id: None,
+                platform: None,
+                uid: None,
+            }
+        };
+
+        Ok(init)
+    }
+
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    pub fn get_sender(&self) -> Option<Arc<Mutex<Sender<TelemetryEvent>>>> {
+        self.sender.clone()
+    }
+
+    pub fn get_receiver(&self) -> Option<Arc<Mutex<Receiver<TelemetryEvent>>>> {
+        self.receiver.clone()
+    }
+
+    pub fn get_custom_agent_id(&self) -> Option<&str> {
+        self.custom_agent_id.as_deref()
+    }
+
+    pub fn set_custom_agent_id(&mut self, custom_agent_id: String) {
+        self.custom_agent_id = Some(custom_agent_id);
+    }
+
+    pub fn set_platform(&mut self, platform: String) {
+        self.platform = Some(platform);
+    }
+
+    pub fn set_uid(&mut self, uid: String) {
+        self.uid = Some(uid);
+    }
+
+    pub fn get_platform(&self) -> Option<String> {
+        self.platform.clone()
+    }
+
+    pub fn get_uid(&self) -> Option<String> {
+        self.uid.clone()
+    }
+}

--- a/src/ureq_dns_resolver.rs
+++ b/src/ureq_dns_resolver.rs
@@ -1,0 +1,136 @@
+use std::sync::Arc;
+
+use ureq::Agent;
+/*
+   The following modules `fixed_resolver` and `certificate_verifier_no_hostname` are from this
+   website:
+   https://scvalex.net/posts/48/
+*/
+mod fixed_resolver {
+    //! A DNS resolver that always returns the same value regardless of
+    //! the host it was queried for.
+
+    use std::net::SocketAddr;
+
+    pub struct FixedResolver(pub SocketAddr);
+
+    impl ureq::Resolver for FixedResolver {
+        fn resolve(&self, _netloc: &str) -> std::io::Result<Vec<SocketAddr>> {
+            Ok(vec![self.0])
+        }
+    }
+}
+mod certificate_verifier_no_hostname {
+    use rustls::{
+        client::{ServerCertVerified, ServerCertVerifier},
+        Certificate, Error as TlsError, ServerName,
+    };
+    use std::time::SystemTime;
+    use webpki::{EndEntityCert, SignatureAlgorithm, TlsServerTrustAnchors};
+
+    pub struct CertificateVerifierNoHostname<'a> {
+        pub trustroots: &'a TlsServerTrustAnchors<'a>,
+    }
+
+    static SUPPORTED_SIG_ALGS: &[&SignatureAlgorithm] = &[
+        &webpki::ECDSA_P256_SHA256,
+        &webpki::ECDSA_P256_SHA384,
+        &webpki::ECDSA_P384_SHA256,
+        &webpki::ECDSA_P384_SHA384,
+        &webpki::ED25519,
+        &webpki::RSA_PSS_2048_8192_SHA256_LEGACY_KEY,
+        &webpki::RSA_PSS_2048_8192_SHA384_LEGACY_KEY,
+        &webpki::RSA_PSS_2048_8192_SHA512_LEGACY_KEY,
+        &webpki::RSA_PKCS1_2048_8192_SHA256,
+        &webpki::RSA_PKCS1_2048_8192_SHA384,
+        &webpki::RSA_PKCS1_2048_8192_SHA512,
+        &webpki::RSA_PKCS1_3072_8192_SHA384,
+    ];
+
+    impl ServerCertVerifier for CertificateVerifierNoHostname<'_> {
+        /// Will verify the certificate is valid in the following ways:
+        /// - Signed by a valid root
+        /// - Not Expired
+        ///
+        /// Based on a https://github.com/ctz/rustls/issues/578#issuecomment-816712636
+        fn verify_server_cert(
+            &self,
+            end_entity: &Certificate,
+            intermediates: &[Certificate],
+            _server_name: &ServerName,
+            _scts: &mut dyn Iterator<Item = &[u8]>,
+            ocsp_response: &[u8],
+            _now: SystemTime,
+        ) -> Result<ServerCertVerified, TlsError> {
+            let end_entity_cert = webpki::EndEntityCert::try_from(end_entity.0.as_ref())
+                .map_err(|err| TlsError::General(err.to_string()))?;
+
+            let chain: Vec<&[u8]> = intermediates.iter().map(|cert| cert.0.as_ref()).collect();
+
+            // Validate the certificate is valid, signed by a trusted root, and not
+            // expired.
+            let now = SystemTime::now();
+            let webpki_now =
+                webpki::Time::try_from(now).map_err(|_| TlsError::FailedToGetCurrentTime)?;
+
+            let _cert: EndEntityCert = end_entity_cert
+                .verify_is_valid_tls_server_cert(
+                    SUPPORTED_SIG_ALGS,
+                    self.trustroots,
+                    &chain,
+                    webpki_now,
+                )
+                .map_err(|err| TlsError::General(err.to_string()))
+                .map(|_| end_entity_cert)?;
+
+            if !ocsp_response.is_empty() {
+                //trace!("Unvalidated OCSP response: {:?}", ocsp_response.to_vec());
+            }
+            Ok(ServerCertVerified::assertion())
+        }
+    }
+}
+
+pub struct InternalAgent(Agent);
+
+impl InternalAgent {
+    pub fn new(ip: &str, port: &str) -> Self {
+        use certificate_verifier_no_hostname::CertificateVerifierNoHostname;
+        use fixed_resolver::FixedResolver;
+
+        let mut root_store = rustls::RootCertStore::empty();
+
+        // This adds webpki_roots certs.
+        root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+            rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
+                ta.subject,
+                ta.spki,
+                ta.name_constraints,
+            )
+        }));
+
+        // See rustls documentation for more configuration options.
+        let tls_config = rustls::ClientConfig::builder()
+            .with_safe_defaults()
+            .with_custom_certificate_verifier(Arc::new(CertificateVerifierNoHostname {
+                trustroots: &webpki_roots::TLS_SERVER_ROOTS,
+            }))
+            .with_no_client_auth();
+
+        // Build a ureq agent with the rustls config.
+        let agent = ureq::builder()
+            .tls_config(Arc::new(tls_config))
+            .resolver(FixedResolver(format!("{ip}:{port}").parse().unwrap()))
+            .build();
+
+        Self(agent)
+    }
+}
+
+impl std::ops::Deref for InternalAgent {
+    type Target = Agent;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}


### PR DESCRIPTION
It adds telemetry to the BlindAI server.

- It uses the `args` method in `EnclaveBuilder` to pass the arguments `platform`, `uid` and `agent_id` to the enclave.
- It also solves a DNS resolution error as regards making http requests from within the enclave.